### PR TITLE
Fix `unbound variable` error

### DIFF
--- a/apt.sh
+++ b/apt.sh
@@ -370,4 +370,8 @@ main() {
     fi
 }
 
-main "$@"
+if [ $# -gt 0 ]; then
+    main "$@"
+else
+    apt_help
+fi


### PR DESCRIPTION
Fixes #1 

Adds argument quantity checker. If it's more than **0** run normally (`main "$@"`), otherwise display help (`apt_help`).